### PR TITLE
Added random password creation

### DIFF
--- a/terraform/parameter_store.tf
+++ b/terraform/parameter_store.tf
@@ -2,26 +2,34 @@ resource "aws_ssm_parameter" "wordpress-db-host" {
   name        = "/wordpress/WORDPRESS_DB_HOST"
   description = "The host parameter to be used by the container and DB"
   type        = "SecureString"
-  value       = "secret"
+  value       = random_password.value.result
 }
 
 resource "aws_ssm_parameter" "wordpress-db-user" {
   name        = "/wordpress/WORDPRESS_DB_USER"
   description = "The user parameter to be used by the container and DB"
   type        = "SecureString"
-  value       = "secret"
+  value       = random_password.value.result
 }
 
 resource "aws_ssm_parameter" "wordpress-db-password" {
   name        = "/wordpress/WORDPRESS_DB_PASSWORD"
   description = "The password parameter to be used by the container and DB"
   type        = "SecureString"
-  value       = "secret"
+  value       = random_password.value.result
 }
 
 resource "aws_ssm_parameter" "wordpress-db-name" {
   name        = "/wordpress/WORDPRESS_DB_NAME"
   description = "The name parameter to be used by the container and DB"
   type        = "SecureString"
-  value       = "secret"
+  value       = random_password.value.result
 }
+
+resource "random_password" "value" {
+  length           = 10
+  special          = true
+  override_special = "_%@"
+}
+
+


### PR DESCRIPTION
Used `random_password` for our values instead of a string that would later have to be modified manually via aws console. It creates a random password, not displayed in console output that is saved in the parameter store. 

I did a test run on my machine and it worked. After terraform apply,
- Log in to AWS console then go to/type "Systems Manager" service, which is located under "Management & Governance".
- Navigate to "Parameter Store", under Application Management. 
I could see all four values ("details" tab) in "Parameter Store"  created as random strings. 